### PR TITLE
Remove block of committing binary assemblies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ x86/
 [Aa][Rr][Mm]/
 [Aa][Rr][Mm]64/
 bld/
-[Bb]in/
 [Oo]bj/
 [Oo]ut/
 [Ll]og/


### PR DESCRIPTION
Update the current `git` configuration in `.gitignore` to allow .NET assemblies to be included with the project, so external stakeholders can reuse the compiled assemblies from the FedRAMP developers without needing to explicitly recompile the C# OSCALHelperClasses library themselves.